### PR TITLE
Keep ACP manifest version aligned with 0.3.0 release

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-acp";
-export const PLUGIN_VERSION = "0.2.4";
+export const PLUGIN_VERSION = "0.3.0";
 
 export const DEFAULT_CONFIG = {
   enabledAgents: "claude,codex,gemini,opencode",


### PR DESCRIPTION
## Summary
- update `PLUGIN_VERSION` to match the released package version
- keep the manifest-reported version aligned with what operators see in Paperclip

## Why
Paperclip reads the plugin manifest version during local-path upgrades. With the stale constant, successful upgrades still looked stuck on `0.2.4`.

Fixes #6

## Verification
- `npm run build`