### PR TITLE
feat: idle/max-age session reaper

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,12 @@ export const DEFAULT_CONFIG = {
   sessionIdleTimeoutMs: 30 * 60 * 1000, // 30 minutes
   sessionMaxAgeMs: 8 * 60 * 60 * 1000, // 8 hours
   maxSessionsPerThread: 5,
+  // How often the idle/max-age reaper scans active sessions.
+  reaperIntervalMs: 60 * 1000, // 1 minute
+  // TTL for orphaned plugin_state rows for sessions that no longer have an
+  // in-process entry (e.g. after a worker restart). Scaffolded for a future
+  // SDK state.list-driven cross-restart purge — no consumer yet.
+  sessionRowTtlDays: 30,
 };
 
 export const METRIC_NAMES = {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -69,6 +69,20 @@ const manifest: PaperclipPluginManifestV1 = {
         description: "Maximum concurrent ACP sessions allowed per chat thread.",
         default: DEFAULT_CONFIG.maxSessionsPerThread,
       },
+      reaperIntervalMs: {
+        type: "number",
+        title: "Reaper scan interval (ms)",
+        description:
+          "How often the idle/max-age reaper scans active sessions. Must be well under sessionIdleTimeoutMs and sessionMaxAgeMs.",
+        default: DEFAULT_CONFIG.reaperIntervalMs,
+      },
+      sessionRowTtlDays: {
+        type: "number",
+        title: "Session row TTL (days)",
+        description:
+          "TTL for orphaned plugin_state rows (sessions with no in-process entry, e.g. after a worker restart). Scaffolded for a future cross-restart purge that depends on the SDK's state.list API — no consumer reads this yet.",
+        default: DEFAULT_CONFIG.sessionRowTtlDays,
+      },
       // --- Phase 2: Orchestration migration config ---
       peakHourEnabled: {
         type: "boolean",

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -1,0 +1,31 @@
+import type { AcpSession } from "./types.js";
+
+export type ReapReason = "idle timeout exceeded" | "max age exceeded";
+
+/**
+ * Pure decision function: given a session snapshot and thresholds, decide
+ * whether it should be reaped and why. Returns null when the session is
+ * either within thresholds or already in a terminal state.
+ *
+ * When both thresholds are exceeded, idle is reported as the reason. This is
+ * an arbitrary tiebreak — both signals mean the session should close.
+ *
+ * Missing timestamps fall back to 0 so a broken session (no createdAt /
+ * lastActivityAt recorded) is reaped immediately rather than appearing
+ * perpetually fresh.
+ */
+export function computeReapReason(
+  now: number,
+  session: Pick<AcpSession, "state" | "lastActivityAt" | "createdAt">,
+  idleTimeoutMs: number,
+  maxAgeMs: number,
+): ReapReason | null {
+  if (session.state === "closed" || session.state === "error") return null;
+  const lastActivity = session.lastActivityAt ?? session.createdAt ?? 0;
+  const created = session.createdAt ?? 0;
+  const idleFor = now - lastActivity;
+  const ageFor = now - created;
+  if (idleFor > idleTimeoutMs) return "idle timeout exceeded";
+  if (ageFor > maxAgeMs) return "max age exceeded";
+  return null;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -32,7 +32,9 @@ import {
   ATTACHMENT_METRIC_NAMES,
   WEBHOOK_EVENTS,
   ORCHESTRATION_DEFAULTS,
+  DEFAULT_CONFIG,
 } from "./constants.js";
+import { computeReapReason } from "./reaper.js";
 import {
   createAttachment,
   listAttachments,
@@ -70,6 +72,8 @@ type AcpConfig = {
   sessionIdleTimeoutMs: number;
   sessionMaxAgeMs: number;
   maxSessionsPerThread: number;
+  reaperIntervalMs: number;
+  sessionRowTtlDays: number;
 } & OrchestrationConfig;
 
 const plugin = definePlugin({
@@ -458,9 +462,67 @@ const plugin = definePlugin({
       },
     );
 
+    // --- Session idle/max-age reaper ---
+    // The manifest advertises sessionIdleTimeoutMs and sessionMaxAgeMs, but
+    // without this loop neither was enforced — long-running workers could
+    // accumulate orphaned sessions indefinitely. The reaper scans active
+    // sessions every reaperIntervalMs and terminates any that are past idle
+    // or max-age thresholds. Sessions already in a terminal state are
+    // skipped to avoid racing with the normal close path.
+    const idleTimeoutMs = config.sessionIdleTimeoutMs ?? DEFAULT_CONFIG.sessionIdleTimeoutMs;
+    const maxAgeMs = config.sessionMaxAgeMs ?? DEFAULT_CONFIG.sessionMaxAgeMs;
+    const reaperIntervalMs = config.reaperIntervalMs ?? DEFAULT_CONFIG.reaperIntervalMs;
+
+    // In-flight guard: between killSession (in-memory SIGTERM) and closeSession
+    // (async state write) there's a window where a second reaper tick could
+    // observe the session as still non-terminal and issue duplicate teardown.
+    // This set gates that window within a single process.
+    const reapingInFlight = new Set<string>();
+
+    const reaperHandle = setInterval(async () => {
+      const now = Date.now();
+      const activeIds = getActiveSessionIds();
+      for (const id of activeIds) {
+        if (reapingInFlight.has(id)) continue;
+        try {
+          const sess = await getSession(ctx, id);
+          if (!sess) continue;
+          const reason = computeReapReason(now, sess, idleTimeoutMs, maxAgeMs);
+          if (!reason) continue;
+          reapingInFlight.add(id);
+          ctx.logger.info("Reaping ACP session", {
+            sessionId: id,
+            reason,
+            idleMs: now - (sess.lastActivityAt ?? sess.createdAt ?? 0),
+            ageMs: now - (sess.createdAt ?? 0),
+          });
+          try {
+            killSession(id);
+            await closeSession(ctx, id);
+          } finally {
+            reapingInFlight.delete(id);
+          }
+        } catch (err) {
+          reapingInFlight.delete(id);
+          ctx.logger.error("Reaper iteration failed", {
+            sessionId: id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }, reaperIntervalMs);
+    // Don't keep the event loop alive just for the reaper.
+    reaperHandle.unref?.();
+    ctx.logger.info("ACP reaper started", {
+      idleTimeoutMs,
+      maxAgeMs,
+      reaperIntervalMs,
+    });
+
     // --- Cleanup on plugin shutdown ---
 
     ctx.events.on("plugin.stopping" as `plugin.${string}`, async () => {
+      clearInterval(reaperHandle);
       const activeIds = getActiveSessionIds();
       for (const id of activeIds) {
         killSession(id);

--- a/tests/reaper.test.ts
+++ b/tests/reaper.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { computeReapReason } from "../src/reaper.js";
+import type { AcpSession } from "../src/types.js";
+
+type ReapSession = Pick<AcpSession, "state" | "lastActivityAt" | "createdAt">;
+
+const IDLE_MS = 30 * 60_000; // 30 min
+const MAX_AGE_MS = 8 * 3600_000; // 8 hr
+
+describe("computeReapReason", () => {
+  // Fixed epoch ~= 2023-11-14; realistic so timestamps don't go negative
+  // when subtracting hour/day offsets in test cases.
+  const now = 1_700_000_000_000;
+
+  it("reaps when idle timeout is exceeded", () => {
+    const session: ReapSession = {
+      state: "active",
+      lastActivityAt: now - 31 * 60_000,
+      createdAt: now - 60_000,
+    };
+    expect(computeReapReason(now, session, IDLE_MS, MAX_AGE_MS)).toBe(
+      "idle timeout exceeded",
+    );
+  });
+
+  it("reaps when max age is exceeded but session is otherwise active", () => {
+    const session: ReapSession = {
+      state: "active",
+      lastActivityAt: now - 1_000,
+      createdAt: now - 9 * 3600_000,
+    };
+    expect(computeReapReason(now, session, IDLE_MS, MAX_AGE_MS)).toBe(
+      "max age exceeded",
+    );
+  });
+
+  it("reports idle timeout when both thresholds are exceeded (idle takes precedence)", () => {
+    const session: ReapSession = {
+      state: "active",
+      lastActivityAt: now - 31 * 60_000,
+      createdAt: now - 9 * 3600_000,
+    };
+    expect(computeReapReason(now, session, IDLE_MS, MAX_AGE_MS)).toBe(
+      "idle timeout exceeded",
+    );
+  });
+
+  const stale = {
+    lastActivityAt: now - 99 * 3600_000,
+    createdAt: now - 99 * 3600_000,
+  };
+
+  it("skips sessions already in a closed state", () => {
+    const closed: ReapSession = { ...stale, state: "closed" };
+    expect(computeReapReason(now, closed, IDLE_MS, MAX_AGE_MS)).toBeNull();
+  });
+
+  it("skips sessions already in an error state", () => {
+    const errored: ReapSession = { ...stale, state: "error" };
+    expect(computeReapReason(now, errored, IDLE_MS, MAX_AGE_MS)).toBeNull();
+  });
+
+  it("does not reap sessions within both thresholds", () => {
+    const session: ReapSession = {
+      state: "active",
+      lastActivityAt: now - 5_000,
+      createdAt: now - 60_000,
+    };
+    expect(computeReapReason(now, session, IDLE_MS, MAX_AGE_MS)).toBeNull();
+  });
+});


### PR DESCRIPTION
Hi — I've been running this plugin on Windows in a production assistant setup for a few months and built a small set of reliability patches locally. This PR upstreams the one that feels most broadly useful: an idle / max-age session reaper so long-running workers don't leak ACP sessions. First time contributing here, so happy to iterate on naming, defaults, structure, or anything else I've missed.

## Motivation

The manifest already advertises `sessionIdleTimeoutMs` (default 30 min) and `sessionMaxAgeMs` (default 8 hr), but nothing in the worker enforces them. In practice that means ACP sessions can orphan whenever a client disconnects without an explicit `acp-close` — the in-memory session map grows unbounded until the plugin process restarts. On my setup this was visible as a slow drip of stuck sessions over multi-day uptimes.

## What changes

- **`src/reaper.ts`** — new pure decision function `computeReapReason(now, session, idleTimeoutMs, maxAgeMs)`. Returns `"idle timeout exceeded"`, `"max age exceeded"`, or `null` for sessions in terminal state / within thresholds. Extracted so the decision logic can be unit-tested without spinning a worker.
- **`src/worker.ts`** — in `setup`, registers a `setInterval` that iterates `getActiveSessionIds()` every `reaperIntervalMs` and calls `killSession` + `closeSession` for any session returning a non-null reap reason. Sessions already in `closed` / `error` state are skipped (handled inside `computeReapReason`). An in-flight `Set<string>` guards the window between `killSession` (in-memory SIGTERM) and the async `closeSession` state write, so a second tick during a slow state write doesn't issue duplicate teardown. The interval handle is `.unref()`'d and `clearInterval`'d in the existing `plugin.stopping` listener.
- **`src/manifest.ts` + `src/constants.ts`** — two new knobs:
  - `reaperIntervalMs` (default `60_000`) — scan cadence. Consumed by the new reaper.
  - `sessionRowTtlDays` (default `30`) — **scaffolded only**, no consumer yet. It lands here alongside the reaper, but the implementation it targets (a cross-restart purge of orphaned `plugin_state` rows for sessions that no longer have an in-process entry) depends on `plugin-sdk`'s `state.list` API, which was just opened upstream in [paperclipai/paperclip#4240](https://github.com/paperclipai/paperclip/pull/4240). I'd be equally happy dropping this knob from this PR and adding it with its implementation in a follow-up — let me know which you'd prefer.
- **`tests/reaper.test.ts`** — 6 cases against `computeReapReason`: idle threshold, max-age threshold, idle-over-max-age precedence, terminal-state skip split across `closed` and `error`, and within-thresholds no-op.

## Config defaults + overrides

Defaults preserve pre-PR behavior (no enforcement is weaker than 30-min idle / 8-hr max-age enforcement, but the thresholds themselves were already the advertised defaults). To tighten:

```json
{
  "sessionIdleTimeoutMs": 600000,
  "sessionMaxAgeMs": 3600000,
  "reaperIntervalMs": 30000
}
```

To effectively disable (not recommended, but supported): set `sessionIdleTimeoutMs` and `sessionMaxAgeMs` to very large values; the reaper still runs but never reaps.

## Tests

Full suite:

```
 Test Files  10 passed (10)
      Tests  213 passed (213)
   Duration  2.15s
```

The 6 new `tests/reaper.test.ts` cases are green alongside the existing 207.

## Backwards compatibility

- No config field is renamed or removed.
- Defaults for the two new knobs are conservative (60 s scan cadence; 30 d scaffolded TTL with no active consumer).
- The reaper only terminates sessions the plugin already classifies as expired via the already-documented thresholds, so operators who set very long timeouts see no behavior change.

## Out of scope / follow-ups

- **Cross-restart orphan purge.** Once [paperclipai/paperclip#4240](https://github.com/paperclipai/paperclip/pull/4240) (SDK `state.list`) is released and the plugin can declare a compatible peer range, `sessionRowTtlDays` can drive a purge pass for orphaned `plugin_state` rows from prior worker processes. That's a separate PR.
- **Observability metric.** I considered adding an `acp.sessions.reaped` counter alongside the existing `METRIC_NAMES`. Happy to add in this PR if you'd like it; left out to keep the surface small.
- Other local Windows-specific patches (CEO-mode output suppression, Telegram bridge interop, etc.) aren't relevant upstream and aren't part of this PR.

Thanks for maintaining this — let me know if any of the above should be reshaped.
