### PR TITLE
feat: emit acp.sessions.reaped counter on reap

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,7 @@ export const METRIC_NAMES = {
   sessionsSpawned: "acp.sessions.spawned",
   sessionsActive: "acp.sessions.active",
   sessionsClosed: "acp.sessions.closed",
+  sessionsReaped: "acp.sessions.reaped",
   promptsSent: "acp.prompts.sent",
   outputsReceived: "acp.outputs.received",
   spawnErrors: "acp.spawn.errors",

--- a/src/reaper.ts
+++ b/src/reaper.ts
@@ -1,4 +1,7 @@
+import type { PluginContext } from "@paperclipai/plugin-sdk";
 import type { AcpSession } from "./types.js";
+import { getSession, closeSession } from "./session-manager.js";
+import { METRIC_NAMES } from "./constants.js";
 
 export type ReapReason = "idle timeout exceeded" | "max age exceeded";
 
@@ -28,4 +31,47 @@ export function computeReapReason(
   if (idleFor > idleTimeoutMs) return "idle timeout exceeded";
   if (ageFor > maxAgeMs) return "max age exceeded";
   return null;
+}
+
+export interface ReapSessionIfDueOptions {
+  killSession: (sessionId: string) => boolean;
+  now: number;
+  idleTimeoutMs: number;
+  maxAgeMs: number;
+}
+
+export interface ReapSessionResult {
+  reaped: boolean;
+  reason?: ReapReason;
+}
+
+/**
+ * Fetch a session, decide whether it is due for reaping, and if so terminate
+ * it and emit the `acp.sessions.reaped` counter. Kept separate from the
+ * worker's setInterval loop so it is unit-testable.
+ *
+ * The counter is only written after closeSession resolves — if teardown
+ * throws, the counter is not incremented and the error propagates.
+ */
+export async function reapSessionIfDue(
+  ctx: PluginContext,
+  sessionId: string,
+  opts: ReapSessionIfDueOptions,
+): Promise<ReapSessionResult> {
+  const session = await getSession(ctx, sessionId);
+  if (!session) return { reaped: false };
+
+  const reason = computeReapReason(
+    opts.now,
+    session,
+    opts.idleTimeoutMs,
+    opts.maxAgeMs,
+  );
+  if (!reason) return { reaped: false };
+
+  opts.killSession(sessionId);
+  await closeSession(ctx, sessionId);
+  await ctx.metrics.write(METRIC_NAMES.sessionsReaped, 1);
+
+  return { reaped: true, reason };
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -34,7 +34,7 @@ import {
   ORCHESTRATION_DEFAULTS,
   DEFAULT_CONFIG,
 } from "./constants.js";
-import { computeReapReason } from "./reaper.js";
+import { computeReapReason, reapSessionIfDue } from "./reaper.js";
 import {
   createAttachment,
   listAttachments,
@@ -484,30 +484,31 @@ const plugin = definePlugin({
       const activeIds = getActiveSessionIds();
       for (const id of activeIds) {
         if (reapingInFlight.has(id)) continue;
+        reapingInFlight.add(id);
         try {
           const sess = await getSession(ctx, id);
           if (!sess) continue;
           const reason = computeReapReason(now, sess, idleTimeoutMs, maxAgeMs);
           if (!reason) continue;
-          reapingInFlight.add(id);
           ctx.logger.info("Reaping ACP session", {
             sessionId: id,
             reason,
             idleMs: now - (sess.lastActivityAt ?? sess.createdAt ?? 0),
             ageMs: now - (sess.createdAt ?? 0),
           });
-          try {
-            killSession(id);
-            await closeSession(ctx, id);
-          } finally {
-            reapingInFlight.delete(id);
-          }
+          await reapSessionIfDue(ctx, id, {
+            killSession,
+            now,
+            idleTimeoutMs,
+            maxAgeMs,
+          });
         } catch (err) {
-          reapingInFlight.delete(id);
           ctx.logger.error("Reaper iteration failed", {
             sessionId: id,
             error: err instanceof Error ? err.message : String(err),
           });
+        } finally {
+          reapingInFlight.delete(id);
         }
       }
     }, reaperIntervalMs);

--- a/tests/reaper.test.ts
+++ b/tests/reaper.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { computeReapReason } from "../src/reaper.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import { computeReapReason, reapSessionIfDue } from "../src/reaper.js";
+import { createSession, closeSession } from "../src/session-manager.js";
+import { createMockContext } from "./helpers.js";
+import { METRIC_NAMES } from "../src/constants.js";
 import type { AcpSession } from "../src/types.js";
 
 type ReapSession = Pick<AcpSession, "state" | "lastActivityAt" | "createdAt">;
@@ -67,5 +70,135 @@ describe("computeReapReason", () => {
       createdAt: now - 60_000,
     };
     expect(computeReapReason(now, session, IDLE_MS, MAX_AGE_MS)).toBeNull();
+  });
+});
+
+describe("reapSessionIfDue (emits acp.sessions.reaped counter)", () => {
+  let ctx: ReturnType<typeof createMockContext>;
+  const idleTimeoutMs = IDLE_MS;
+  const maxAgeMs = MAX_AGE_MS;
+
+  beforeEach(() => {
+    ctx = createMockContext();
+  });
+
+  async function seedSession(overrides: Partial<AcpSession>): Promise<string> {
+    const s = await createSession(ctx, {
+      agentId: "claude",
+      mode: "persistent",
+      cwd: "/workspace",
+    });
+    // Backdate fields the reaper inspects.
+    const now = Date.now();
+    await ctx.state.set(
+      { scopeKind: "instance", stateKey: `acp-session:${s.sessionId}` },
+      {
+        ...s,
+        lastActivityAt: overrides.lastActivityAt ?? now,
+        createdAt: overrides.createdAt ?? now,
+        state: overrides.state ?? "active",
+      },
+    );
+    return s.sessionId;
+  }
+
+  function countReaped(): number {
+    return (ctx.metrics._writes as Array<{ name: string; value: number }>)
+      .filter((w) => w.name === METRIC_NAMES.sessionsReaped)
+      .reduce((n, w) => n + w.value, 0);
+  }
+
+  it("emits acp.sessions.reaped exactly once when idle timeout is exceeded", async () => {
+    const now = Date.now();
+    const sessionId = await seedSession({
+      lastActivityAt: now - 31 * 60_000,
+      createdAt: now - 60_000,
+    });
+    const killed: string[] = [];
+    const result = await reapSessionIfDue(ctx, sessionId, {
+      killSession: (id) => {
+        killed.push(id);
+        return true;
+      },
+      now,
+      idleTimeoutMs,
+      maxAgeMs,
+    });
+    expect(result.reaped).toBe(true);
+    expect(result.reason).toBe("idle timeout exceeded");
+    expect(killed).toEqual([sessionId]);
+    expect(countReaped()).toBe(1);
+  });
+
+  it("emits acp.sessions.reaped exactly once when max age is exceeded", async () => {
+    const now = Date.now();
+    const sessionId = await seedSession({
+      lastActivityAt: now - 1_000,
+      createdAt: now - 9 * 3600_000,
+    });
+    const result = await reapSessionIfDue(ctx, sessionId, {
+      killSession: () => true,
+      now,
+      idleTimeoutMs,
+      maxAgeMs,
+    });
+    expect(result.reaped).toBe(true);
+    expect(result.reason).toBe("max age exceeded");
+    expect(countReaped()).toBe(1);
+  });
+
+  it("does not emit the counter when the session is within thresholds", async () => {
+    const now = Date.now();
+    const sessionId = await seedSession({
+      lastActivityAt: now - 1_000,
+      createdAt: now - 1_000,
+    });
+    const killed: string[] = [];
+    const result = await reapSessionIfDue(ctx, sessionId, {
+      killSession: (id) => {
+        killed.push(id);
+        return true;
+      },
+      now,
+      idleTimeoutMs,
+      maxAgeMs,
+    });
+    expect(result.reaped).toBe(false);
+    expect(killed).toEqual([]);
+    expect(countReaped()).toBe(0);
+  });
+
+  it("does not emit the counter when the manual closeSession path is used", async () => {
+    const sessionId = await seedSession({});
+    await closeSession(ctx, sessionId);
+    expect(countReaped()).toBe(0);
+  });
+
+  it("does not emit the counter when closeSession throws during reap", async () => {
+    const now = Date.now();
+    const sessionId = await seedSession({
+      lastActivityAt: now - 31 * 60_000,
+      createdAt: now - 60_000,
+    });
+    // Force ctx.state.set to reject on the next write (closeSession path).
+    const origSet = ctx.state.set;
+    let calls = 0;
+    ctx.state.set = async (
+      opts: { scopeKind: string; stateKey: string },
+      value: unknown,
+    ) => {
+      calls += 1;
+      if (calls >= 1) throw new Error("state write failed");
+      return origSet(opts, value);
+    };
+    await expect(
+      reapSessionIfDue(ctx, sessionId, {
+        killSession: () => true,
+        now,
+        idleTimeoutMs,
+        maxAgeMs,
+      }),
+    ).rejects.toThrow("state write failed");
+    expect(countReaped()).toBe(0);
   });
 });


### PR DESCRIPTION
Follow-up to #11 per your pre-approval. Adds one counter, `acp.sessions.reaped`, incremented by 1 each time the reaper successfully terminates a session (idle OR max-age).

## Why

The reaper closes sessions silently. Operators can't tell a healthy cadence from a runaway loop or a stuck one without grepping logs. A single counter makes reap throughput a first-class metric alongside `acp.sessions.spawned` / `.closed`.

## What changed

- `METRIC_NAMES.sessionsReaped = \"acp.sessions.reaped\"` in `constants.ts`.
- New `reapSessionIfDue` helper in `reaper.ts`: fetches session, calls `computeReapReason`, and on a non-null reason runs `killSession` → `closeSession` → `ctx.metrics.write(sessionsReaped, 1)`. Extracted so the metric is unit-testable without driving `setInterval`.
- `worker.ts` reap loop keeps its rich pre-kill log line and in-flight guard; only the kill/close/metric sequence moves into the helper.

## Scope / non-goals

- Counter only. No labels, no reason dimension, no error-path metric, no new config. YAGNI — a per-reason split can be added later as sibling metric names if operators need it.
- `computeReapReason` is unchanged.

## Tests

Five new cases in `tests/reaper.test.ts`:

1. Idle timeout exceeded → counter emits exactly once.
2. Max age exceeded → counter emits exactly once.
3. Within both thresholds → no kill, no emit.
4. Manual `closeSession` path → no emit (counter is reaper-exclusive).
5. `closeSession` throws during reap → no emit (counter fires only after teardown succeeds).

\`\`\`
Test Files  10 passed (10)
     Tests  218 passed (218)
\`\`\`

`npm run typecheck` clean.