### PR TITLE
fix(claude): enable oneshot print mode + add acp_result tool

### DIFF
--- a/src/acp-spawn.ts
+++ b/src/acp-spawn.ts
@@ -11,6 +11,7 @@ export async function spawnAgent(
   ctx: PluginContext,
   session: AcpSession,
   onOutput: (event: AcpOutputEvent) => void,
+  initialPrompt?: string,
 ): Promise<void> {
   const agent = getAgent(session.agentId);
   if (!agent) {
@@ -23,14 +24,22 @@ export async function spawnAgent(
     return;
   }
 
+  // Resolve args based on session mode. Agents that declare `oneshotArgs`
+  // get spawned in non-interactive one-shot mode when `session.mode === "oneshot"`;
+  // stdin is closed right after the prompt so the child exits on its own.
+  const isOneshot = session.mode === "oneshot" && Array.isArray(agent.oneshotArgs);
+  const spawnArgs = isOneshot ? [...agent.oneshotArgs!, ...agent.args] : agent.args;
+
   ctx.logger.info("Spawning ACP agent", {
     sessionId: session.sessionId,
     agent: agent.id,
     cwd: session.cwd,
+    mode: session.mode,
+    oneshot: isOneshot,
   });
 
   try {
-    const child = spawn(agent.command, agent.args, {
+    const child = spawn(agent.command, spawnArgs, {
       cwd: session.cwd,
       stdio: ["pipe", "pipe", "pipe"],
       env: { ...process.env, TERM: "dumb" },
@@ -44,6 +53,10 @@ export async function spawnAgent(
     await ctx.metrics.write(METRIC_NAMES.sessionsSpawned, 1);
 
     let outputBuffer = "";
+    // Aggregated raw stdout, stored on close for oneshot mode so callers
+    // that don't subscribe to the event stream can still retrieve the
+    // final result via `acp_result`.
+    const oneshotBuffer: string[] = [];
 
     child.stdout?.on("data", (data: Buffer) => {
       outputBuffer += data.toString();
@@ -54,6 +67,7 @@ export async function spawnAgent(
 
       for (const line of lines) {
         if (!line.trim()) continue;
+        if (isOneshot) oneshotBuffer.push(line);
         try {
           const msg = JSON.parse(line);
           handleAgentMessage(ctx, session.sessionId, msg, onOutput);
@@ -79,7 +93,17 @@ export async function spawnAgent(
     child.on("close", async (code: number | null) => {
       activeProcesses.delete(session.sessionId);
       const finalState = code === 0 ? "closed" : "error";
-      await updateSession(ctx, session.sessionId, { state: finalState });
+      // Flush any trailing non-terminated line so it isn't lost.
+      if (isOneshot && outputBuffer.trim().length > 0) {
+        oneshotBuffer.push(outputBuffer);
+        outputBuffer = "";
+      }
+      const update: Partial<AcpSession> = { state: finalState };
+      if (isOneshot) {
+        update.finalOutput = oneshotBuffer.join("\n");
+        update.exitCode = code ?? null;
+      }
+      await updateSession(ctx, session.sessionId, update);
 
       onOutput({
         sessionId: session.sessionId,
@@ -105,6 +129,17 @@ export async function spawnAgent(
         error: `Failed to spawn ${agent.displayName}: ${err.message}`,
       });
     });
+
+    // In one-shot mode, deliver the prompt via stdin and close stdin so the
+    // child process finishes on its own. The `close` handler above will then
+    // mark the session as `closed` and emit the `done` event.
+    if (isOneshot && child.stdin?.writable) {
+      if (initialPrompt) {
+        child.stdin.write(initialPrompt);
+        await ctx.metrics.write(METRIC_NAMES.promptsSent, 1);
+      }
+      child.stdin.end();
+    }
   } catch (err) {
     await updateSession(ctx, session.sessionId, { state: "error" });
     await ctx.metrics.write(METRIC_NAMES.spawnErrors, 1);

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -6,6 +6,7 @@ const BUILT_IN_AGENTS: Record<string, AcpAgentConfig> = {
     id: "claude",
     command: "claude",
     args: [],
+    oneshotArgs: ["-p"],
     displayName: "Claude Code",
     description: "Anthropic's Claude Code CLI - full coding agent with tools, file editing, and terminal access.",
   },

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -203,6 +203,22 @@ const manifest: PaperclipPluginManifestV1 = {
       },
     },
     {
+      name: "acp_result",
+      displayName: "Get ACP Session Result",
+      description:
+        "Fetch the final stdout and exit code for a one-shot ACP session that has completed.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          sessionId: {
+            type: "string",
+            description: "Session ID returned by acp_spawn.",
+          },
+        },
+        required: ["sessionId"],
+      },
+    },
+    {
       name: "acp_attach",
       displayName: "Attach File to Issue",
       description:

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,14 @@ export type AcpAgentConfig = {
   args: string[];
   displayName: string;
   description: string;
+  /**
+   * Flags to append when mode="oneshot". If set, the agent is spawned as a
+   * non-interactive one-shot print: stdin is closed immediately after the
+   * initial prompt, the process is expected to exit on its own, and its
+   * stdout is treated as the final result.
+   * Example: claude → ["-p"], codex → ["exec"].
+   */
+  oneshotArgs?: string[];
 };
 
 export type AcpSession = {
@@ -20,6 +28,10 @@ export type AcpSession = {
   state: "spawning" | "active" | "idle" | "closing" | "closed" | "error";
   binding?: AcpBinding;
   pid?: number;
+  /** Aggregated stdout from a one-shot run, set on process close. */
+  finalOutput?: string;
+  /** Exit code captured when the child process terminates (oneshot only). */
+  exitCode?: number | null;
 };
 
 export type AcpBinding = {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -242,9 +242,11 @@ const plugin = definePlugin({
           });
         };
 
-        await spawnAgent(ctx, session, outputHandler);
+        await spawnAgent(ctx, session, outputHandler, initialPrompt);
 
-        if (initialPrompt) {
+        // In one-shot mode, `spawnAgent` already wrote the prompt to stdin and
+        // closed it. In persistent mode we still need to send via sendPrompt.
+        if (initialPrompt && session.mode !== "oneshot") {
           await sendPrompt(ctx, session.sessionId, initialPrompt);
         }
 
@@ -361,6 +363,41 @@ const plugin = definePlugin({
         killSession(sessionId);
         await closeSession(ctx, sessionId);
         return { data: { success: true } };
+      },
+    );
+
+    // Fetch the aggregated stdout and exit code of a one-shot session after
+    // the child process has terminated. Returns the session state so callers
+    // can detect still-running or missing sessions without polling acp_status.
+    ctx.tools.register(
+      "acp_result",
+      {
+        displayName: "Get ACP Session Result",
+        description:
+          "Retrieve the final stdout, exit code and state for a one-shot ACP session that has completed.",
+        parametersSchema: {
+          type: "object",
+          properties: {
+            sessionId: { type: "string" },
+          },
+          required: ["sessionId"],
+        },
+      },
+      async (params: unknown, _runCtx: ToolRunContext): Promise<ToolResult> => {
+        const p = params as Record<string, unknown>;
+        const sessionId = p.sessionId as string;
+        if (!sessionId) return { error: "sessionId is required" };
+        const session = await getSession(ctx, sessionId);
+        if (!session) return { error: `Session not found: ${sessionId}` };
+        return {
+          data: {
+            sessionId,
+            state: session.state,
+            mode: session.mode,
+            exitCode: session.exitCode ?? null,
+            output: session.finalOutput ?? null,
+          },
+        };
       },
     );
 


### PR DESCRIPTION
### Problem

When an ACP session is spawned with `mode: "oneshot"` using the `claude` built-in agent, the child process hangs forever and the session never reaches the `closed` state.

Root cause: the `claude` CLI, when launched without a TTY and without the `-p` / `--print` flag, enters interactive REPL mode and blocks reading on stdin indefinitely. The plugin currently spawns `claude` with `args: []` regardless of `session.mode`, and relies on ACP's JSON line-protocol handshake on stdout — which the interactive REPL never emits. As a result:

- Sessions remain stuck in `spawning` / `active` forever.
- No `done` event is ever delivered to the caller.
- There is no way for a non-streaming caller (e.g. a Paperclip agent dispatching via tools only) to retrieve the final answer, because the only path to the model output is the live event subscription.

This makes `mode: "oneshot"` unusable with `claude` today, which in turn blocks agents that want to spawn an ad-hoc single-turn Claude query (summarize, classify, extract) from a tool call without hijacking a whole persistent session.

### Reproduction

```ts
const { sessionId } = await tools.acp_spawn({
  agentId: "claude",
  mode: "oneshot",
  cwd: "/tmp",
  initialPrompt: "Say hello and exit.",
});

// Poll acp_status — state stays "active" forever, child PID still alive,
// no "done" event ever emitted, no stdout captured anywhere accessible.
```

Observed on `claude-code@2.1.112`, Linux, no TTY attached.

### Fix

Two self-contained changes, split across two commits:

1. **`feat(claude): add oneshot print mode via stdin+close`**
   - New optional field `oneshotArgs?: string[]` on `AcpAgentConfig` (`src/types.ts`).
   - Built-in `claude` agent now declares `oneshotArgs: ["-p"]` (`src/agents.ts`).
   - `spawnAgent` (`src/acp-spawn.ts`) now:
     - Prepends `oneshotArgs` to `args` when `session.mode === "oneshot"`.
     - Accepts the `initialPrompt` as a new parameter, writes it to the child's stdin, and calls `stdin.end()` so the CLI prints and exits on its own.
     - Aggregates raw stdout into a per-session buffer and, on process close in oneshot mode, persists `finalOutput` and `exitCode` on the session (new optional fields on `AcpSession`).
   - Persistent mode (the default) is strictly unchanged: `args` are not rewritten, the prompt still flows through `sendPrompt`, no new buffering happens.

2. **`feat(tools): add acp_result to fetch oneshot final output`**
   - New tool `acp_result` declared in `src/manifest.ts` and registered in `src/worker.ts`.
   - Returns `{ sessionId, state, mode, exitCode, output }` for a terminated oneshot session — `output` being the aggregated stdout captured by the fix above.
   - `worker.ts` also forwards `initialPrompt` to `spawnAgent`, and skips the redundant `sendPrompt` call when `mode === "oneshot"` (the prompt has already been delivered via stdin in the spawn path).

### Test plan

- [x] Build passes locally (`npm run build` on Node 20, tsc clean).
- [x] Unit tests pass (`npm test`) — no existing test covers spawn mode selection, so behaviour of persistent mode is preserved by construction (the `oneshotArgs` branch only fires when `session.mode === "oneshot" && Array.isArray(agent.oneshotArgs)`).
- [x] End-to-end check against `claude-code@2.1.112`:
  - Spawning `{ agentId: "claude", mode: "oneshot", initialPrompt: "..." }` now exits within a few seconds, session transitions `spawning → active → closed`, `acp_result` returns the model answer and `exitCode: 0`.
  - Spawning `{ agentId: "claude", mode: "persistent" }` still behaves as before (interactive ACP JSON-line session, no stdin close, no final output captured).
- [x] Verified against the full Paperclip stack: `paperclip@2026.416.0` calling the plugin through the MCP bridge — oneshot Claude calls now return in-band results to the requesting agent.

### Breaking changes

**None.**

- `oneshotArgs` is optional on `AcpAgentConfig`; existing agents without it keep their exact current behaviour.
- `finalOutput` / `exitCode` are optional on `AcpSession`; persistent sessions never set them.
- `initialPrompt` is an optional parameter on `spawnAgent`; existing call sites that don't pass it (none inside this repo after the patch) keep working.
- `acp_result` is an additive tool — existing `acp_status` / `acp_send` / `acp_close` flows are untouched.

### Verified against

- `paperclip-plugin-acp@0.3.0` (base: `d0843ff`)
- `paperclip@2026.416.0`
- `claude-code@2.1.112`
