### PR TITLE
fix(gemini): pass --acp to enable ACP server mode

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -19,7 +19,7 @@ const BUILT_IN_AGENTS: Record<string, AcpAgentConfig> = {
   gemini: {
     id: "gemini",
     command: "gemini",
-    args: [],
+    args: ["--acp"],
     displayName: "Gemini CLI",
     description: "Google's Gemini CLI - coding agent with Gemini models.",
   },


### PR DESCRIPTION
## Summary
- One-line fix: `gemini` agent in `BUILT_IN_AGENTS` was spawning with no args, leaving the CLI in interactive mode where it hangs on stdin instead of speaking ACP JSON-RPC.
- Adds `--acp` to match how the gemini CLI documents its ACP server mode.

## Background
Other adapters (claude, codex, opencode) start in ACP mode by default. Gemini is the only one that needs an explicit flag.

Without this fix, the JSON-RPC `initialize` handshake never completes and sessions time out at the 30s ceiling.

## Test plan
- [x] `pnpm test` green locally (213/213 on this branch)
- [x] Manually verified: spawning `gemini --acp` and sending an ACP `initialize` frame returns a response in <500ms; without the flag, no response within 30s.