### PR TITLE
Sandbox isolation for spawned coding-agent subprocesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,50 @@ The plugin exposes these tools to Paperclip agents:
 | `acp_cancel` | Cancel the current turn (SIGINT) |
 | `acp_close` | Close a session and remove thread bindings |
 
+## Sandbox isolation (v0.6.0+)
+
+Each spawned agent subprocess runs inside a disposable host-isolation
+sandbox so the operator's `~/.claude/` config, hooks, and shell env do
+not bleed into the spawned agent.
+
+What the sandbox enforces:
+
+- **Isolated HOME** — every spawn gets its own temp dir under
+  `/tmp/paperclip-acp-sandbox-<uuid>/`. `$HOME` inside the child points
+  at `<sandbox>/HOME`, not the operator's real home directory.
+- **Minimal `~/.claude/settings.json`** — the sandbox writes exactly
+  `{"hooks":{}}` into the isolated HOME. The operator's PostToolUse,
+  Stop, and other hooks cannot fire inside the spawned agent and
+  therefore cannot inject `[Task Active]`-style marker text into its
+  stdout.
+- **Env allowlist + denylist** — the child env starts from `{}`. Only
+  `HOME`, `PATH`, `LANG`, `LC_ALL`, `TERM`, and `ANTHROPIC_API_KEY` pass
+  through. Anything matching `*TOKEN*`, `*SECRET*`, `*KEY*`,
+  `CLAUDE_*`, `PAPERCLIP_*`, `OPENAI_*`, `SESSION_*`, `MCP_*`, or
+  `KAIROS_*` is stripped. `ANTHROPIC_API_KEY` is the one explicit
+  exception to the `*KEY*` pattern (required for `claude -p`).
+- **Pinned PATH** — `/usr/bin:/bin:/usr/local/bin:<claude-bin-dir>`.
+  The parent's PATH (which may include the operator's project bins,
+  homebrew, etc.) does not leak through.
+- **Cleanup on success / preservation on failure** — sandbox dirs are
+  deleted when the agent exits with code 0 and preserved on non-zero
+  exits so the operator can inspect what the child saw. A TTL sweeper
+  removes any sandbox older than 24h on plugin startup and on each
+  reaper tick (path-traversal-guarded — only directories under
+  `/tmp/paperclip-acp-sandbox-` are eligible).
+
+Source-of-truth reference: this is a TypeScript port of the kairos
+`daemon/sandbox.py` design that closed the chat-bleed property class
+identified in commit `dc9884a`. See `src/sandbox.ts` for the
+implementation and `tests/sandbox.test.ts` for the unit-test contract.
+
 ## How it works
 
 ```
 Chat message (Telegram/Discord/Slack)
     -> Chat plugin emits acp:spawn / acp:message event
     -> ACP plugin routes to bound session
-    -> Coding agent subprocess (stdio)
+    -> Coding agent subprocess (stdio, isolated HOME, scrubbed env)
     -> Agent output emitted as acp:output event
     -> Chat plugin sends response to thread
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperclip-plugin-acp",
-  "version": "0.5.0",
+  "version": "0.6.0-spritehc.1",
   "type": "module",
   "main": "./dist/index.js",
   "paperclipPlugin": {

--- a/src/acp-spawn.ts
+++ b/src/acp-spawn.ts
@@ -4,6 +4,7 @@ import { getAgent } from "./agents.js";
 import { updateSession } from "./session-manager.js";
 import type { AcpSession, AcpOutputEvent } from "./types.js";
 import { METRIC_NAMES } from "./constants.js";
+import { buildSandboxProfile, cleanupSandbox } from "./sandbox.js";
 
 const activeProcesses = new Map<string, ChildProcess>();
 
@@ -38,11 +39,34 @@ export async function spawnAgent(
     oneshot: isOneshot,
   });
 
+  // Build a disposable sandbox profile per session (spec 167). The sandbox
+  // gives the subprocess an isolated $HOME with an empty hooks settings.json
+  // and a scrubbed env (denylist for CLAUDE_*/PAPERCLIP_*/KAIROS_*/OPENAI_*/
+  // *TOKEN*/*SECRET*/*KEY* with ANTHROPIC_API_KEY exempted). Failure to
+  // build the sandbox is fatal — we MUST NOT fall back to spreading the
+  // parent process env into the child.
+  let sandbox;
+  try {
+    sandbox = buildSandboxProfile(session.sessionId);
+  } catch (err) {
+    await updateSession(ctx, session.sessionId, { state: "error" });
+    await ctx.metrics.write(METRIC_NAMES.spawnErrors, 1);
+    onOutput({
+      sessionId: session.sessionId,
+      type: "error",
+      error: `Sandbox build failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return;
+  }
+  await updateSession(ctx, session.sessionId, {
+    sandboxPath: sandbox.sandboxRoot,
+  });
+
   try {
     const child = spawn(agent.command, spawnArgs, {
       cwd: session.cwd,
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, TERM: "dumb" },
+      env: { ...sandbox.env, TERM: "dumb" },
     });
 
     activeProcesses.set(session.sessionId, child);
@@ -116,6 +140,19 @@ export async function spawnAgent(
       } else {
         await ctx.metrics.write(METRIC_NAMES.spawnErrors, 1);
       }
+
+      // Spec 167: delete sandbox on success; preserve on non-zero exit for
+      // post-mortem. cleanupSandbox is idempotent — safe to also be called
+      // from session-manager.closeSession on a reaper-driven close.
+      try {
+        cleanupSandbox(sandbox.sandboxRoot, code === 0);
+      } catch (err) {
+        ctx.logger.warn("sandbox cleanup failed", {
+          sessionId: session.sessionId,
+          sandboxRoot: sandbox.sandboxRoot,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     });
 
     child.on("error", async (err: Error) => {
@@ -128,6 +165,14 @@ export async function spawnAgent(
         type: "error",
         error: `Failed to spawn ${agent.displayName}: ${err.message}`,
       });
+
+      // Spawn failure — preserve sandbox so the operator can inspect what
+      // the child would have seen (settings.json, env_dump if added later).
+      try {
+        cleanupSandbox(sandbox.sandboxRoot, false);
+      } catch {
+        /* ignore */
+      }
     });
 
     // In one-shot mode, deliver the prompt via stdin and close stdin so the

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const PLUGIN_ID = "paperclip-plugin-acp";
-export const PLUGIN_VERSION = "0.3.0";
+export const PLUGIN_VERSION = "0.6.0-spritehc.1";
 
 export const DEFAULT_CONFIG = {
   enabledAgents: "claude,codex,gemini,opencode",

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -1,0 +1,274 @@
+/**
+ * Host-isolation sandbox for ACP worker spawns.
+ *
+ * Source-of-truth port: kairos/daemon/sandbox.py (commit dc9884a — chat-bleed
+ * incident, May 2026). Each ACP subprocess gets:
+ *   - an isolated temporary HOME under /tmp/paperclip-acp-sandbox-<uuid>/HOME
+ *   - a minimal ~/.claude/settings.json containing exactly {"hooks":{}} so the
+ *     operator's PostToolUse/Stop hooks do NOT leak into the spawned agent's
+ *     stdout (this is what produced the `[Task Active]` bleed in dc9884a)
+ *   - an env dict built from an explicit allowlist with a denylist override:
+ *     CLAUDE_, PAPERCLIP_, KAIROS_, OPENAI_, SESSION_, MCP_ prefixed keys
+ *     and any TOKEN / SECRET / KEY substring match are stripped, EXCEPT
+ *     ANTHROPIC_API_KEY which is required for `claude -p` to function and is
+ *     explicitly exempted.
+ *
+ * The sandbox dir is deleted on clean exit (code === 0) and preserved on any
+ * non-zero exit for post-mortem inspection. A TTL sweeper deletes any sandbox
+ * older than 24h to backstop orphan accumulation if a session is reaped or
+ * the plugin restarts mid-flight.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execSync } from "node:child_process";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const _SANDBOX_TMP_PREFIX = "paperclip-acp-sandbox-";
+
+/** Env keys allowed to pass through to the worker subprocess.
+ *  HOME/PATH are always overridden, but listed here for symmetry with kairos. */
+export const _ENV_ALLOWLIST = new Set<string>([
+  "HOME",
+  "PATH",
+  "LANG",
+  "LC_ALL",
+  "TERM",
+  "ANTHROPIC_API_KEY",
+]);
+
+/** Env-key glob patterns (case-insensitive) that must NOT leak through. */
+export const _ENV_DENYLIST_PATTERNS: readonly string[] = [
+  "*TOKEN*",
+  "*SECRET*",
+  "*KEY*",
+  "CLAUDE_*",
+  "PAPERCLIP_*",
+  "OPENAI_*",
+  "SESSION_*",
+  "MCP_*",
+  "KAIROS_*",
+];
+
+/** Keys that ARE allowed despite matching a denylist pattern. */
+export const _ENV_DENYLIST_EXCEPTIONS = new Set<string>([
+  "ANTHROPIC_API_KEY",
+]);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SandboxProfile {
+  /** ACP session id this sandbox is bound to. */
+  sessionId: string;
+  /** Absolute path /tmp/paperclip-acp-sandbox-<uuid>/ — the dir to rm on cleanup. */
+  sandboxRoot: string;
+  /** Absolute path sandboxRoot + "/HOME" — what HOME points at inside subprocess. */
+  home: string;
+  /** Env dict to pass to spawn(): allowlist applied + denylist filtered + pinned PATH. */
+  env: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** Convert a fnmatch-style glob to a RegExp anchored at start/end. */
+function globToRegex(glob: string): RegExp {
+  const escaped = glob
+    .split("*")
+    .map((s) => s.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))
+    .join(".*");
+  return new RegExp(`^${escaped}$`, "i");
+}
+
+const _DENY_REGEXES: readonly RegExp[] = _ENV_DENYLIST_PATTERNS.map(globToRegex);
+
+/** True if `key` matches any denylist pattern (case-insensitive). */
+export function _matchesDeny(key: string): boolean {
+  for (const re of _DENY_REGEXES) {
+    if (re.test(key)) return true;
+  }
+  return false;
+}
+
+/** Resolve the directory containing the `claude` binary, with a safe fallback. */
+function resolveClaudeBinDir(): string {
+  try {
+    const out = execSync("which claude", { encoding: "utf8" }).trim();
+    if (out) return path.dirname(out);
+  } catch {
+    // `which` exits non-zero if claude isn't on PATH — fall through.
+  }
+  return "/usr/local/bin";
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an env dict from `parentEnv`. Starts from an empty object (NEVER
+ * spreads parentEnv) and copies only allowlisted keys, then re-applies the
+ * denylist as a defensive sweep. Pins PATH and overrides HOME to `home`.
+ *
+ * `ANTHROPIC_API_KEY` survives the *KEY* denylist via the exceptions set.
+ */
+export function buildEnv(
+  parentEnv: NodeJS.ProcessEnv,
+  home: string,
+): Record<string, string> {
+  const claudeBinDir = resolveClaudeBinDir();
+  const pinnedPath = `/usr/bin:/bin:/usr/local/bin:${claudeBinDir}`;
+
+  const env: Record<string, string> = {};
+
+  // Copy allowlisted keys from parent env, applying denylist with exceptions.
+  for (const key of _ENV_ALLOWLIST) {
+    if (key === "HOME" || key === "PATH") continue; // overridden below
+    const value = parentEnv[key];
+    if (value === undefined) continue;
+    if (_matchesDeny(key) && !_ENV_DENYLIST_EXCEPTIONS.has(key)) continue;
+    env[key] = value;
+  }
+
+  // Required overrides — set last so they cannot be filtered out.
+  env.PATH = pinnedPath;
+  env.HOME = home;
+
+  // Defensive: ensure no denied key sneaks through (e.g., via future allowlist
+  // additions). Mirrors kairos sandbox.py:189-191.
+  for (const key of Object.keys(env)) {
+    if (key === "HOME" || key === "PATH") continue;
+    if (_matchesDeny(key) && !_ENV_DENYLIST_EXCEPTIONS.has(key)) {
+      delete env[key];
+    }
+  }
+
+  return env;
+}
+
+/**
+ * Write `{home}/.claude/settings.json` containing exactly `{"hooks":{}}`.
+ * Throws if the target path is a symlink (defends against TOCTOU attacks
+ * pointing settings.json at the operator's real settings).
+ */
+export function writeMinimalSettings(home: string): void {
+  const claudeDir = path.join(home, ".claude");
+  fs.mkdirSync(claudeDir, { recursive: true });
+  const settingsPath = path.join(claudeDir, "settings.json");
+  fs.writeFileSync(settingsPath, '{"hooks":{}}', { encoding: "utf8" });
+  // Re-stat after write to assert the result is a regular file, not a symlink
+  // someone planted between mkdir and writeFileSync.
+  const stat = fs.lstatSync(settingsPath);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`settings.json must not be a symlink: ${settingsPath}`);
+  }
+}
+
+/**
+ * Build a fresh sandbox profile for `sessionId`. Creates the tmp dir, writes
+ * the minimal settings.json, and constructs the scrubbed env dict.
+ */
+export function buildSandboxProfile(sessionId: string): SandboxProfile {
+  const sandboxRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), _SANDBOX_TMP_PREFIX),
+  );
+  const home = path.join(sandboxRoot, "HOME");
+  fs.mkdirSync(home, { recursive: true });
+  writeMinimalSettings(home);
+  const env = buildEnv(process.env, home);
+  return { sessionId, sandboxRoot, home, env };
+}
+
+/**
+ * Delete the sandbox dir on success; preserve on failure for post-mortem.
+ * Idempotent — safe to call multiple times (e.g. from both acp-spawn close
+ * handler and session-manager closeSession). ENOENT and other rm errors are
+ * silenced because the dir may already be gone.
+ */
+export function cleanupSandbox(sandboxPath: string, success: boolean): void {
+  if (!success) {
+    // Preserve for post-mortem. Caller should log.
+    return;
+  }
+  try {
+    fs.rmSync(sandboxPath, { recursive: true, force: true });
+  } catch {
+    // Idempotent: ignore errors (ENOENT, EACCES on stale handles, etc).
+  }
+}
+
+/**
+ * Sweep any sandbox dir under os.tmpdir() older than `ttlHours`.
+ *
+ * Path-traversal guard: only directories whose RESOLVED path starts with
+ * `path.join(os.tmpdir(), _SANDBOX_TMP_PREFIX)` are eligible for deletion.
+ * A malicious symlink named `paperclip-acp-sandbox-evil` pointing at
+ * `/etc/passwd` would fail the prefix check after resolution.
+ *
+ * Returns the count of dirs removed.
+ */
+export function sweepExpiredSandboxes(ttlHours: number = 24): number {
+  const tmpdir = os.tmpdir();
+  // Resolve tmpdir so the path-traversal prefix check works on macOS where
+  // /var/folders/... is itself a symlink to /private/var/folders/...
+  let resolvedTmpdir: string;
+  try {
+    resolvedTmpdir = fs.realpathSync(tmpdir);
+  } catch {
+    resolvedTmpdir = tmpdir;
+  }
+  const allowedPrefix = path.join(resolvedTmpdir, _SANDBOX_TMP_PREFIX);
+  const ttlMs = ttlHours * 3_600_000;
+  const now = Date.now();
+  let count = 0;
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(tmpdir);
+  } catch {
+    return 0;
+  }
+
+  for (const name of entries) {
+    if (!name.startsWith(_SANDBOX_TMP_PREFIX)) continue;
+    const full = path.join(tmpdir, name);
+
+    // Resolve symlinks before checking the prefix — this is the
+    // path-traversal guard. A symlink named paperclip-acp-sandbox-evil
+    // pointing at /etc would resolve to /etc which fails the startsWith.
+    let resolved: string;
+    try {
+      resolved = fs.realpathSync(full);
+    } catch {
+      // Broken symlink or permission error — skip.
+      continue;
+    }
+    if (!resolved.startsWith(allowedPrefix)) {
+      // Path-traversal attempt or symlink outside the tmpdir prefix.
+      continue;
+    }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(full);
+    } catch {
+      continue;
+    }
+    if (now - stat.mtimeMs < ttlMs) continue;
+
+    try {
+      fs.rmSync(full, { recursive: true, force: true });
+      count += 1;
+    } catch {
+      // Already gone, permission error — ignore.
+    }
+  }
+
+  return count;
+}

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -9,6 +9,7 @@ import type {
 } from "./types.js";
 import { getAgent } from "./agents.js";
 import { DEFAULT_CONFIG } from "./constants.js";
+import { cleanupSandbox } from "./sandbox.js";
 
 const STATE_PREFIX = "acp-session:";
 const SESSIONS_PREFIX = "acp_sessions_";
@@ -98,6 +99,22 @@ export async function closeSession(
       session.binding.threadId,
       sessionId,
     );
+  }
+
+  // Spec 167: second cleanup path for reaper-driven closes. cleanupSandbox is
+  // idempotent (rmSync force:true, errors swallowed) so this is safe even if
+  // the acp-spawn child.close handler already deleted the dir. Sessions
+  // created before v0.6.0 have no sandboxPath; skip them.
+  if (session.sandboxPath) {
+    try {
+      cleanupSandbox(session.sandboxPath, true);
+    } catch (err) {
+      ctx.logger.warn("sandbox cleanup failed in closeSession", {
+        sessionId,
+        sandboxPath: session.sandboxPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,12 @@ export type AcpSession = {
   finalOutput?: string;
   /** Exit code captured when the child process terminates (oneshot only). */
   exitCode?: number | null;
+  /**
+   * Absolute path to the disposable sandbox dir created for this session's
+   * subprocess (host isolation, spec 167). Present only for sessions spawned
+   * by v0.6.0+; v0.5.0-era sessions read back without this field.
+   */
+  sandboxPath?: string;
 };
 
 export type AcpBinding = {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -35,6 +35,7 @@ import {
   DEFAULT_CONFIG,
 } from "./constants.js";
 import { computeReapReason, reapSessionIfDue } from "./reaper.js";
+import { sweepExpiredSandboxes } from "./sandbox.js";
 import {
   createAttachment,
   listAttachments,
@@ -89,6 +90,18 @@ const plugin = definePlugin({
       peakHourEnabled: config.peakHourEnabled,
       sharedPoolSize: config.sharedPoolSize,
     });
+
+    // Spec 167: startup sweep of orphan sandboxes left behind by crashes or
+    // ungraceful restarts. Path-traversal-guarded; safe even if /tmp has
+    // unrelated content.
+    try {
+      const swept = sweepExpiredSandboxes(24);
+      ctx.logger.info("ACP startup sandbox sweep complete", { swept });
+    } catch (err) {
+      ctx.logger.warn("ACP startup sandbox sweep failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
 
     const enabledAgents = parseEnabledAgents(config?.enabledAgents ?? "claude,codex,gemini,opencode");
     if (enabledAgents.length === 0) {
@@ -516,8 +529,27 @@ const plugin = definePlugin({
     // This set gates that window within a single process.
     const reapingInFlight = new Set<string>();
 
+    // Spec 167: opportunistic orphan-sandbox sweep on each reaper tick,
+    // throttled so we sweep at most once per hour (a TTL of 24h doesn't need
+    // higher resolution than that, and readdirSync over /tmp is non-trivial).
+    let lastSweepAt = 0;
+    const SWEEP_THROTTLE_MS = 3_600_000;
+
     const reaperHandle = setInterval(async () => {
       const now = Date.now();
+      if (now - lastSweepAt >= SWEEP_THROTTLE_MS) {
+        lastSweepAt = now;
+        try {
+          const swept = sweepExpiredSandboxes(24);
+          if (swept > 0) {
+            ctx.logger.info("ACP reaper sandbox sweep removed orphans", { swept });
+          }
+        } catch (err) {
+          ctx.logger.warn("ACP reaper sandbox sweep failed", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
       const activeIds = getActiveSessionIds();
       for (const id of activeIds) {
         if (reapingInFlight.has(id)) continue;

--- a/tests/acp-spawn.test.ts
+++ b/tests/acp-spawn.test.ts
@@ -501,3 +501,137 @@ describe("getActiveSessionIds", () => {
     expect(ids).toHaveLength(3);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Spec 167 — Sandbox wiring integration tests
+// ---------------------------------------------------------------------------
+
+describe("spawnAgent — sandbox isolation (spec 167)", () => {
+  let ctx: ReturnType<typeof createMockContext>;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    ctx = createMockContext();
+    vi.clearAllMocks();
+    mockUpdateSession.mockResolvedValue(undefined);
+    for (const id of getActiveSessionIds()) {
+      killSession(id);
+    }
+    originalEnv = { ...process.env };
+  });
+
+  function restoreEnv() {
+    for (const k of Object.keys(process.env)) delete process.env[k];
+    Object.assign(process.env, originalEnv);
+  }
+
+  it("spawn() receives env from the sandbox, NOT a spread of process.env", async () => {
+    // Pre-seed parent env with denylist keys that MUST NOT leak through.
+    process.env.PAPERCLIP_AGENT_ID = "leaked";
+    process.env.CLAUDE_AGENT_ID = "leaked";
+    process.env.KAIROS_SPAWNED = "1";
+    process.env.OPENAI_API_KEY = "sk-leaked";
+
+    const child = createFakeChild();
+    mockGetAgent.mockReturnValue(makeAgent("claude"));
+    mockSpawn.mockReturnValue(child);
+    const session = makeSession({ sessionId: "s-env-scrub" });
+
+    await spawnAgent(ctx, session, () => {});
+
+    expect(mockSpawn).toHaveBeenCalled();
+    const spawnEnv = mockSpawn.mock.calls[0][2].env as Record<string, string>;
+    expect(spawnEnv.PAPERCLIP_AGENT_ID).toBeUndefined();
+    expect(spawnEnv.CLAUDE_AGENT_ID).toBeUndefined();
+    expect(spawnEnv.KAIROS_SPAWNED).toBeUndefined();
+    expect(spawnEnv.OPENAI_API_KEY).toBeUndefined();
+    // The TERM:"dumb" override still wins (set after sandbox env spread).
+    expect(spawnEnv.TERM).toBe("dumb");
+    // HOME points at a sandbox dir, not the operator home.
+    expect(spawnEnv.HOME).toContain("paperclip-acp-sandbox-");
+
+    restoreEnv();
+  });
+
+  it("preserves ANTHROPIC_API_KEY through the spawn env (allowlist exception)", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+
+    const child = createFakeChild();
+    mockGetAgent.mockReturnValue(makeAgent("claude"));
+    mockSpawn.mockReturnValue(child);
+    const session = makeSession({ sessionId: "s-anthropic-key" });
+
+    await spawnAgent(ctx, session, () => {});
+
+    const spawnEnv = mockSpawn.mock.calls[0][2].env as Record<string, string>;
+    expect(spawnEnv.ANTHROPIC_API_KEY).toBe("sk-ant-test");
+
+    restoreEnv();
+  });
+
+  it("persists sandboxPath to session state via updateSession", async () => {
+    const child = createFakeChild();
+    mockGetAgent.mockReturnValue(makeAgent("claude"));
+    mockSpawn.mockReturnValue(child);
+    const session = makeSession({ sessionId: "s-sandbox-path" });
+
+    await spawnAgent(ctx, session, () => {});
+
+    // Find the updateSession call that set sandboxPath.
+    const sandboxPathCalls = mockUpdateSession.mock.calls.filter(
+      (call: unknown[]) =>
+        typeof (call[2] as Record<string, unknown>).sandboxPath === "string",
+    );
+    expect(sandboxPathCalls.length).toBeGreaterThanOrEqual(1);
+    const sbPath = (sandboxPathCalls[0][2] as Record<string, string>).sandboxPath;
+    expect(sbPath).toContain("paperclip-acp-sandbox-");
+  });
+
+  it("cleans up sandbox dir on exit code 0", async () => {
+    const child = createFakeChild();
+    mockGetAgent.mockReturnValue(makeAgent("claude"));
+    mockSpawn.mockReturnValue(child);
+    const session = makeSession({ sessionId: "s-cleanup-ok" });
+
+    await spawnAgent(ctx, session, () => {});
+    const sandboxPathCall = mockUpdateSession.mock.calls.find(
+      (call: unknown[]) =>
+        typeof (call[2] as Record<string, unknown>).sandboxPath === "string",
+    );
+    const sbPath = (sandboxPathCall![2] as Record<string, string>).sandboxPath;
+    const fs = await import("node:fs");
+    expect(fs.existsSync(sbPath)).toBe(true);
+
+    child.emit("close", 0);
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(fs.existsSync(sbPath)).toBe(false);
+  });
+
+  it("preserves sandbox dir on non-zero exit code (for post-mortem)", async () => {
+    const child = createFakeChild();
+    mockGetAgent.mockReturnValue(makeAgent("claude"));
+    mockSpawn.mockReturnValue(child);
+    const session = makeSession({ sessionId: "s-cleanup-fail" });
+
+    await spawnAgent(ctx, session, () => {});
+    const sandboxPathCall = mockUpdateSession.mock.calls.find(
+      (call: unknown[]) =>
+        typeof (call[2] as Record<string, unknown>).sandboxPath === "string",
+    );
+    const sbPath = (sandboxPathCall![2] as Record<string, string>).sandboxPath;
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+
+    child.emit("close", 1);
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(fs.existsSync(sbPath)).toBe(true);
+    // settings.json should still be there for inspection.
+    expect(fs.existsSync(path.join(sbPath, "HOME", ".claude", "settings.json")))
+      .toBe(true);
+
+    // Test-only cleanup so we don't leak.
+    fs.rmSync(sbPath, { recursive: true, force: true });
+  });
+});

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Sandbox unit tests — exercises every FR in spec 167:
+ *   FR-2/3/4: env allowlist + denylist + ANTHROPIC_API_KEY exception
+ *   FR-5:     pinned PATH
+ *   FR-6/7:   isolated HOME + minimal settings.json
+ *   FR-8:     cleanup on success / preservation on failure / idempotency
+ *   FR-9/10:  TTL sweep + path-traversal guard
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  buildEnv,
+  buildSandboxProfile,
+  cleanupSandbox,
+  sweepExpiredSandboxes,
+  writeMinimalSettings,
+  _matchesDeny,
+  _SANDBOX_TMP_PREFIX,
+} from "../src/sandbox.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Track sandboxes we create so afterEach can rm them. */
+const createdDirs: string[] = [];
+
+afterEach(() => {
+  while (createdDirs.length > 0) {
+    const dir = createdDirs.pop()!;
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// buildEnv — denylist enforcement (FR-2/3/4)
+// ---------------------------------------------------------------------------
+
+describe("buildEnv", () => {
+  it("drops PAPERCLIP_AGENT_ID / CLAUDE_AGENT_ID / KAIROS_SPAWNED / OPENAI_API_KEY", () => {
+    const env = buildEnv(
+      {
+        PAPERCLIP_AGENT_ID: "test",
+        CLAUDE_AGENT_ID: "test",
+        KAIROS_SPAWNED: "1",
+        OPENAI_API_KEY: "sk-test",
+        TERM: "dumb",
+      },
+      "/tmp/fake-home",
+    );
+    expect(env.PAPERCLIP_AGENT_ID).toBeUndefined();
+    expect(env.CLAUDE_AGENT_ID).toBeUndefined();
+    expect(env.KAIROS_SPAWNED).toBeUndefined();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  it("keeps ANTHROPIC_API_KEY despite *KEY* denylist (exception)", () => {
+    const env = buildEnv(
+      {
+        ANTHROPIC_API_KEY: "sk-ant-test",
+        OPENAI_API_KEY: "sk-other",
+      },
+      "/tmp/fake-home",
+    );
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-test");
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  it("strips arbitrary *TOKEN* and *SECRET* keys even if not on allowlist", () => {
+    // These wouldn't even be copied because they're not on the allowlist,
+    // but _matchesDeny is the contract surface and we test it explicitly.
+    expect(_matchesDeny("GITHUB_TOKEN")).toBe(true);
+    expect(_matchesDeny("AWS_SECRET_ACCESS_KEY")).toBe(true);
+    expect(_matchesDeny("STRIPE_SECRET")).toBe(true);
+    expect(_matchesDeny("SOMETHING_KEY")).toBe(true);
+  });
+
+  it("matches denylist case-insensitively", () => {
+    expect(_matchesDeny("paperclip_agent_id")).toBe(true);
+    expect(_matchesDeny("Claude_Agent_Id")).toBe(true);
+  });
+
+  it("does NOT flag harmless keys (TERM, LANG, LC_ALL)", () => {
+    expect(_matchesDeny("TERM")).toBe(false);
+    expect(_matchesDeny("LANG")).toBe(false);
+    expect(_matchesDeny("LC_ALL")).toBe(false);
+    expect(_matchesDeny("HOME")).toBe(false);
+    expect(_matchesDeny("PATH")).toBe(false);
+  });
+
+  it("pins PATH and does not expose parent PATH", () => {
+    const env = buildEnv(
+      { PATH: "/evil/path:/some/other" },
+      "/tmp/fake-home",
+    );
+    expect(env.PATH).toBeDefined();
+    expect(env.PATH).not.toBe("/evil/path:/some/other");
+    expect(env.PATH).toContain("/usr/bin");
+    expect(env.PATH).toContain("/bin");
+    expect(env.PATH).toContain("/usr/local/bin");
+  });
+
+  it("sets HOME to the sandbox path argument", () => {
+    const env = buildEnv({}, "/tmp/sandbox-x/HOME");
+    expect(env.HOME).toBe("/tmp/sandbox-x/HOME");
+  });
+
+  it("does not spread the entire parent env (must start from empty)", () => {
+    const env = buildEnv(
+      {
+        SOME_RANDOM_VAR: "should-not-survive",
+        ANOTHER_VAR: "neither",
+        TERM: "dumb",
+      },
+      "/tmp/fake-home",
+    );
+    expect(env.SOME_RANDOM_VAR).toBeUndefined();
+    expect(env.ANOTHER_VAR).toBeUndefined();
+    expect(env.TERM).toBe("dumb");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeMinimalSettings (FR-7)
+// ---------------------------------------------------------------------------
+
+describe("writeMinimalSettings", () => {
+  it('writes exactly {"hooks":{}}', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "sbtest-home-"));
+    createdDirs.push(home);
+    writeMinimalSettings(home);
+    const content = fs.readFileSync(
+      path.join(home, ".claude", "settings.json"),
+      "utf8",
+    );
+    expect(content).toBe('{"hooks":{}}');
+  });
+
+  it("the written settings.json is NOT a symlink", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "sbtest-home-"));
+    createdDirs.push(home);
+    writeMinimalSettings(home);
+    const stat = fs.lstatSync(path.join(home, ".claude", "settings.json"));
+    expect(stat.isSymbolicLink()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSandboxProfile (integration of buildEnv + writeMinimalSettings)
+// ---------------------------------------------------------------------------
+
+describe("buildSandboxProfile", () => {
+  it("creates a sandbox dir under tmpdir with the canonical prefix", () => {
+    const profile = buildSandboxProfile("sess-1");
+    createdDirs.push(profile.sandboxRoot);
+    expect(profile.sandboxRoot.startsWith(path.join(os.tmpdir(), _SANDBOX_TMP_PREFIX)))
+      .toBe(true);
+    expect(fs.existsSync(profile.sandboxRoot)).toBe(true);
+    expect(fs.existsSync(profile.home)).toBe(true);
+    expect(fs.existsSync(path.join(profile.home, ".claude", "settings.json")))
+      .toBe(true);
+  });
+
+  it("env.HOME points at the sandbox home", () => {
+    const profile = buildSandboxProfile("sess-2");
+    createdDirs.push(profile.sandboxRoot);
+    expect(profile.env.HOME).toBe(profile.home);
+  });
+
+  it("each call returns a distinct sandbox dir", () => {
+    const a = buildSandboxProfile("sess-a");
+    const b = buildSandboxProfile("sess-b");
+    createdDirs.push(a.sandboxRoot, b.sandboxRoot);
+    expect(a.sandboxRoot).not.toBe(b.sandboxRoot);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanupSandbox (FR-8)
+// ---------------------------------------------------------------------------
+
+describe("cleanupSandbox", () => {
+  it("deletes the sandbox dir on success=true", () => {
+    const profile = buildSandboxProfile("sess-cleanup-ok");
+    expect(fs.existsSync(profile.sandboxRoot)).toBe(true);
+    cleanupSandbox(profile.sandboxRoot, true);
+    expect(fs.existsSync(profile.sandboxRoot)).toBe(false);
+  });
+
+  it("preserves the sandbox dir on success=false", () => {
+    const profile = buildSandboxProfile("sess-cleanup-fail");
+    createdDirs.push(profile.sandboxRoot);
+    cleanupSandbox(profile.sandboxRoot, false);
+    expect(fs.existsSync(profile.sandboxRoot)).toBe(true);
+    expect(fs.existsSync(path.join(profile.home, ".claude", "settings.json")))
+      .toBe(true);
+  });
+
+  it("is idempotent — second call on already-deleted dir does not throw", () => {
+    const profile = buildSandboxProfile("sess-idempotent");
+    cleanupSandbox(profile.sandboxRoot, true);
+    expect(() => cleanupSandbox(profile.sandboxRoot, true)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sweepExpiredSandboxes (FR-9/10)
+// ---------------------------------------------------------------------------
+
+describe("sweepExpiredSandboxes", () => {
+  it("removes a sandbox dir whose mtime is older than ttlHours", () => {
+    // Create a dir, then backdate its mtime by 26h.
+    const oldDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), `${_SANDBOX_TMP_PREFIX}sweep-old-`),
+    );
+    const past = new Date(Date.now() - 26 * 3_600_000);
+    fs.utimesSync(oldDir, past, past);
+    // Sanity: dir exists before sweep.
+    expect(fs.existsSync(oldDir)).toBe(true);
+    sweepExpiredSandboxes(24);
+    expect(fs.existsSync(oldDir)).toBe(false);
+  });
+
+  it("preserves a sandbox dir whose mtime is fresher than ttlHours", () => {
+    const freshDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), `${_SANDBOX_TMP_PREFIX}sweep-fresh-`),
+    );
+    createdDirs.push(freshDir);
+    sweepExpiredSandboxes(24);
+    expect(fs.existsSync(freshDir)).toBe(true);
+  });
+
+  it("path-traversal guard: ignores symlinks resolving outside the prefix", () => {
+    // Plant a symlink in tmpdir whose name matches the prefix but whose target
+    // is OUTSIDE the allowed prefix. After realpathSync, the resolved path
+    // will not start with the prefix and the sweep must skip it.
+    const evilName = `${_SANDBOX_TMP_PREFIX}evil-${Date.now()}`;
+    const evilPath = path.join(os.tmpdir(), evilName);
+    // Point at /etc (a real dir on every macOS / Linux box). /etc is NOT
+    // under the paperclip-acp-sandbox- prefix, so the guard must skip.
+    try {
+      fs.symlinkSync("/etc", evilPath);
+    } catch {
+      // If symlinks aren't permitted (rare), the test is moot — bail gracefully.
+      return;
+    }
+    try {
+      const past = new Date(Date.now() - 48 * 3_600_000);
+      fs.lutimesSync(evilPath, past, past);
+      sweepExpiredSandboxes(24);
+      // /etc must STILL exist.
+      expect(fs.existsSync("/etc")).toBe(true);
+    } finally {
+      try {
+        fs.unlinkSync(evilPath);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  it("returns the count of sandboxes removed", () => {
+    const a = fs.mkdtempSync(
+      path.join(os.tmpdir(), `${_SANDBOX_TMP_PREFIX}sweep-count-a-`),
+    );
+    const b = fs.mkdtempSync(
+      path.join(os.tmpdir(), `${_SANDBOX_TMP_PREFIX}sweep-count-b-`),
+    );
+    const past = new Date(Date.now() - 30 * 3_600_000);
+    fs.utimesSync(a, past, past);
+    fs.utimesSync(b, past, past);
+    const removed = sweepExpiredSandboxes(24);
+    expect(removed).toBeGreaterThanOrEqual(2);
+    expect(fs.existsSync(a)).toBe(false);
+    expect(fs.existsSync(b)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds host-isolated subprocess spawning for coding agents (claude/codex/gemini/opencode) so the agent sees a fresh HOME, a settings.json with no hooks, and a scrubbed env. Eliminates a class of bug where operator-side hook output (e.g., dotclaude `workflow-continuity-gate.sh`) bleeds into agent stdout and gets forwarded to chat platforms via plugin-acp's `output` event.

### What changed

| Phase | Files | Note |
|---|---|---|
| P2 | `src/sandbox.ts` (new, 274 LOC) | Port of kairos `daemon/sandbox.py` — buildSandboxProfile, writeMinimalSettings, buildEnv (allowlist + denylist), cleanupSandbox, sweepExpiredSandboxes |
| P3 | `src/acp-spawn.ts` | Line 33 (formerly `env: { ...process.env, TERM: "dumb" }`) → `env: { ...sandbox.env, TERM: "dumb" }`. Wires cleanupSandbox into close + error handlers. |
| P4 | `src/session-manager.ts`, `src/types.ts` | Adds `sandboxPath?: string` to `AcpSession`; `closeSession` invokes idempotent cleanup |
| P5 | `src/worker.ts` | Startup sweep + hourly-throttled reaper-tick sweep |
| P6 | `README.md`, `package.json`, `src/constants.ts` | Version bump to 0.6.0, sandbox-isolation section in README |

### Design notes

- **Env scrub is conservative**: starts from an empty dict, allowlists `PATH` (pinned), `HOME` (sandbox-overridden), `TERM`, `LANG`, `LC_ALL`, `ANTHROPIC_API_KEY`. Denylist patterns (deny trumps allow except `ANTHROPIC_API_KEY`): `*TOKEN*`, `*SECRET*`, `*KEY*`, `CLAUDE_*`, `PAPERCLIP_*`, `OPENAI_*`, `SESSION_*`, `MCP_*`, `KAIROS_*`. Tested against the full env shape.
- **Path-traversal guard** on sweep: `realpathSync` check + `startsWith(os.tmpdir() + '/paperclip-acp-sandbox-')` prefix. Symlink-to-/etc attack rejected (test: `tests/sandbox.test.ts:239`).
- **Idempotent cleanup**: both close and reaper paths use `fs.rmSync({ force: true, recursive: true })` in try/catch.
- **24h TTL** for orphans.
- **Failure preservation**: sandbox dir kept on non-zero exit for post-mortem.
- **Cross-plugin event namespace unchanged**: `plugin.<source>.acp-spawn` listeners untouched (chat plugins keep working).

### Test plan

- [x] `pnpm install && pnpm typecheck && pnpm build` clean
- [x] `pnpm test` → 243/243 pass (+25 new from 218 baseline)
- [x] Mutation test: reverting `acp-spawn.ts:69` back to `process.env` produces 1 expected test failure (proves substitution is load-bearing)
- [x] Live runtime verification: spawned `claude --print` under sandbox showed zero `[Task Active]` text in stdout (the original bug class)
- [x] All-4-agents smoke: claude/codex/gemini start under sandbox; opencode skipped (binary not installed in test environment)

### Why this exists

Kairos (a sibling daemon that does similar chat→CLI agent dispatch) hit this exact bug: a Telegram-spawned `claude -p` subprocess emitted dotclaude hook text (`[Task Active] X is IMPLEMENTING — blocking exit`) into a user's chat reply. The kairos team patched it with an env marker (`KAIROS_SPAWNED=1`) that hooks check. We're porting the proper structural fix (HOME isolation) instead — no env-marker proliferation needed.

### Compatibility

Existing sessions unaffected — the change applies to new spawns only. No API/contract changes. Manifest unchanged. Drop-in for v0.5.0 consumers.

Happy to iterate on any of this.