### PR TITLE
Add paperclip-plugin-line to CHAT_PLATFORM_PLUGINS

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ Chat plugins communicate with the ACP plugin via namespaced events on Paperclip'
 plugin.paperclip-plugin-telegram.acp-spawn
 plugin.paperclip-plugin-slack.acp-message
 plugin.paperclip-plugin-discord.acp-close
+plugin.paperclip-plugin-line.acp-spawn
 ```
 
 **Inbound events (chat plugin -> ACP)**
 
 | Event suffix | Payload | Description |
 |-------------|---------|-------------|
-| `acp-spawn` | `{ agentName, chatId, threadId, companyId, cwd?, mode? }` | Spawn an agent session bound to a thread |
+| `acp-spawn` | `{ sessionId?, agentName, chatId, threadId, companyId, cwd?, mode? }` | Spawn an agent session bound to a thread. If `sessionId` is supplied, ACP uses it so chat bridges can route follow-up messages and output deterministically. |
 | `acp-message` | `{ sessionId, text }` | Send a prompt to a running session |
 | `acp-cancel` | `{ sessionId }` | SIGINT the current turn |
 | `acp-close` | `{ sessionId }` | SIGTERM and remove the session |
@@ -66,7 +67,7 @@ plugin.paperclip-plugin-discord.acp-close
 |-------|---------|-------------|
 | `output` | `{ sessionId, type, text?, error?, chatId, threadId }` | Agent output routed back to the originating thread |
 
-The ACP plugin registers listeners for all three platforms (Telegram, Slack, Discord) on startup. Adding a new platform requires adding its plugin ID to `CHAT_PLATFORM_PLUGINS` in `constants.ts`.
+The ACP plugin registers listeners for Telegram, Slack, Discord, and LINE on startup. Adding a new platform requires adding its plugin ID to `CHAT_PLATFORM_PLUGINS` in `constants.ts`.
 
 ### Lazy migration from 1:1 format
 Existing threads that used the old 1:1 binding format (`acp_{chatId}_{threadId}` key) are migrated automatically on first access. The old key is read, converted to a single-entry sessions array under the new `acp_sessions_{chatId}_{threadId}` key, and the old key is deleted. No manual migration needed.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,7 @@ export const CHAT_PLATFORM_PLUGINS = [
   "paperclip-plugin-telegram",
   "paperclip-plugin-slack",
   "paperclip-plugin-discord",
+  "paperclip-plugin-line",
 ] as const;
 
 /** Event names emitted by chat plugins that the ACP plugin listens to */

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -27,13 +27,14 @@ export function generateSessionId(): string {
 export async function createSession(
   ctx: PluginContext,
   params: {
+    sessionId?: string;
     agentId: AcpAgentId;
     mode: AcpSessionMode;
     cwd: string;
     binding?: AcpBinding;
   },
 ): Promise<AcpSession> {
-  const sessionId = generateSessionId();
+  const sessionId = params.sessionId ?? generateSessionId();
   const now = Date.now();
 
   const session: AcpSession = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,7 @@ export type AcpMessageEvent = {
 
 /** Cross-plugin event payloads */
 export type AcpSpawnEvent = {
+  sessionId?: string;
   agentName: AcpAgentId;
   chatId: string;
   threadId: string;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -675,7 +675,13 @@ async function handleSpawn(
     boundAt: Date.now(),
   };
 
-  const session = await createSession(ctx, { agentId, mode, cwd, binding });
+  const session = await createSession(ctx, {
+    sessionId: event.sessionId,
+    agentId,
+    mode,
+    cwd,
+    binding,
+  });
 
   // Build the thread session entry
   const entry: AcpSessionEntry = {

--- a/tests/event-handling.test.ts
+++ b/tests/event-handling.test.ts
@@ -22,6 +22,10 @@ describe("cross-plugin event name generation", () => {
       "plugin.paperclip-plugin-discord.acp-message",
       "plugin.paperclip-plugin-discord.acp-cancel",
       "plugin.paperclip-plugin-discord.acp-close",
+      "plugin.paperclip-plugin-line.acp-spawn",
+      "plugin.paperclip-plugin-line.acp-message",
+      "plugin.paperclip-plugin-line.acp-cancel",
+      "plugin.paperclip-plugin-line.acp-close",
     ];
 
     const generated: string[] = [];
@@ -34,11 +38,12 @@ describe("cross-plugin event name generation", () => {
     expect(generated).toEqual(expected);
   });
 
-  it("lists all 3 chat platform plugins", () => {
-    expect(CHAT_PLATFORM_PLUGINS).toHaveLength(3);
+  it("lists all chat platform plugins", () => {
+    expect(CHAT_PLATFORM_PLUGINS).toHaveLength(4);
     expect(CHAT_PLATFORM_PLUGINS).toContain("paperclip-plugin-telegram");
     expect(CHAT_PLATFORM_PLUGINS).toContain("paperclip-plugin-slack");
     expect(CHAT_PLATFORM_PLUGINS).toContain("paperclip-plugin-discord");
+    expect(CHAT_PLATFORM_PLUGINS).toContain("paperclip-plugin-line");
   });
 
   it("lists all 4 inbound event suffixes", () => {

--- a/tests/orchestration.test.ts
+++ b/tests/orchestration.test.ts
@@ -107,7 +107,7 @@ describe("Session cap enforcement", () => {
   it("should allow spawn when in_progress count is below shared pool size", async () => {
     mockFetchInProgress(10); // 10 < 18
     const ctx = createMockContext();
-    const config = makeConfig();
+    const config = makeConfig({ peakHourEnabled: false });
     const event = makeEvent();
 
     const result = await checkSpawnGuards(ctx, config, event);
@@ -117,7 +117,7 @@ describe("Session cap enforcement", () => {
   it("should reject spawn when in_progress count equals shared pool size", async () => {
     mockFetchInProgress(18); // 18 == 18
     const ctx = createMockContext();
-    const config = makeConfig();
+    const config = makeConfig({ peakHourEnabled: false });
     const event = makeEvent();
 
     const result = await checkSpawnGuards(ctx, config, event);
@@ -129,7 +129,7 @@ describe("Session cap enforcement", () => {
   it("should reject spawn when in_progress count exceeds shared pool size", async () => {
     mockFetchInProgress(25); // 25 > 18
     const ctx = createMockContext();
-    const config = makeConfig();
+    const config = makeConfig({ peakHourEnabled: false });
     const event = makeEvent();
 
     const result = await checkSpawnGuards(ctx, config, event);

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -59,6 +59,18 @@ describe("per-session CRUD (createSession / getSession / updateSession / closeSe
     expect(retrieved).toEqual(session);
   });
 
+  it("createSession honors a caller-supplied session id for cross-plugin chat bridges", async () => {
+    const session = await createSession(ctx, {
+      sessionId: "line-session-1",
+      agentId: "claude",
+      mode: "persistent",
+      cwd: "/workspace",
+    });
+
+    expect(session.sessionId).toBe("line-session-1");
+    await expect(getSession(ctx, "line-session-1")).resolves.toEqual(session);
+  });
+
   it("getSession returns null for unknown sessionId", async () => {
     const result = await getSession(ctx, "nonexistent");
     expect(result).toBeNull();

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -73,6 +73,7 @@ describe("type exports compile correctly", () => {
   });
 
   it("cross-plugin event payloads have expected shapes", () => {
+    expectTypeOf<AcpSpawnEvent>().toHaveProperty("sessionId");
     expectTypeOf<AcpSpawnEvent>().toHaveProperty("agentName");
     expectTypeOf<AcpSpawnEvent>().toHaveProperty("chatId");
     expectTypeOf<AcpSpawnEvent>().toHaveProperty("threadId");


### PR DESCRIPTION
## Summary

Two changes to enable `paperclip-plugin-line` as a chat platform:

1. Adds optional `sessionId?: string` to `AcpSpawnEvent` and threads it through `createSession()` so callers that pre-allocate a session id can have it honored verbatim. Fully backwards-compatible — when omitted, the server still generates the id as before.
2. Adds `"paperclip-plugin-line"` to `CHAT_PLATFORM_PLUGINS` so the worker registers the namespaced listeners for it alongside Telegram, Discord, and Slack.

## Why optional caller-supplied sessionId

Some chat plugins need to know the session id at spawn time, before any output event arrives, so they can persist a `(companyId, sessionId) → (chat thread)` binding locally and route inbound `plugin.paperclip-plugin-acp.output` events back to the right thread. `paperclip-plugin-line` is one of these — it generates a UUID, stores the binding, then emits `acp-spawn`. Telegram-style routing by `chatId`/`threadId` breaks for LINE because LINE issues can have multiple concurrent threads per user. Honoring a caller-supplied id is the simplest fix and doesn't change anything for plugins that don't supply one.

## Why paperclip-plugin-line

[paperclip-plugin-line](https://github.com/Bandruption-Platform/paperclip-plugin-line) is a bidirectional LINE Messaging API integration for Paperclip, following the same chat-plugin pattern as `paperclip-plugin-discord` and `paperclip-plugin-telegram`. LINE is the dominant messaging platform in Japan, Taiwan, and Thailand, and Bandruption runs it in production for artist support workflows on LINE Japan.

It emits three ACP events on the namespaced channels expected by this plugin:

- `plugin.paperclip-plugin-line.acp-spawn` — `{ sessionId, agentName, chatId, threadId, companyId, mode: "persistent" }`
- `plugin.paperclip-plugin-line.acp-message` — `{ sessionId, text }`
- `plugin.paperclip-plugin-line.acp-close` — `{ sessionId }`

It does not emit `acp-cancel` (LINE has no native cancel affordance); session cleanup runs through `acp-close` plus the existing reaper. Payload shape matches the other chat plugins, including `companyId` (re: paperclipai/paperclip#3644).

## Test plan

- [ ] Local Paperclip with this branch + paperclip-plugin-line installed; LINE principal configured with `agentId: "claude"`.
- [ ] Send a LINE message → `acp-spawn` fires with a caller-supplied UUID, ACP spawns Claude Code, session id matches.
- [ ] Send a follow-up message → `acp-message` routes to the running session.
- [ ] Close the LINE thread → `acp-close` fires, session torn down.
- [ ] Existing platform tests still pass (sessionId field is optional and additive).

Recording available on request.