### PR TITLE
ci: add zero-cache CI workflow, SHA-pin publish actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run test
+      - run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## What

Repo hardening, first slice (applies identically across the four plugin repos):

- **New `ci.yml`** — typecheck + test + build on every PR and push to `main`. Least-privilege token (`contents: read`), no dependency/build caches (cache poisoning surface), no secrets — safe on fork PRs. Until now the repos had no CI; merge gating was maintainers running the suite locally.
- **`publish.yml` hardened** — third-party actions pinned by full commit SHA (release workflows are a trust boundary), and `actions/checkout` / `actions/setup-node` bumped off deprecated node20 majors to current v6. Publish behavior unchanged: version-gated OIDC publish with provenance.

## Why

Part of a security pass now that the plugins have active co-maintenance: no shared caches in workflows, SHA-pinned actions in release lanes, CI as a required check on `main` (branch ruleset lands right after this merges).

## Verification

The `ci` check running on this very PR is the verification — it must be green before merge.

---
<sub><em>**[@superbiche](https://github.com/superbiche)** · co-maintainer · drafted with Claude Fable 5.</em></sub>

https://claude.ai/code/session_014EtUqWXNruHzvyfeoajMpR
